### PR TITLE
The 'config' variable is already used as an array expression less...

### DIFF
--- a/Loader/YamlFileLoader.php
+++ b/Loader/YamlFileLoader.php
@@ -62,7 +62,7 @@ class YamlFileLoader extends FileLoader
         }
 
         try {
-            $config = $this->yamlParser->parse(file_get_contents($path));
+            $configParsed = $this->yamlParser->parse(file_get_contents($path));
         } catch (ParseException $e) {
             throw new \InvalidArgumentException(sprintf('The file "%s" does not contain valid YAML.', $path), 0, $e);
         }
@@ -71,16 +71,16 @@ class YamlFileLoader extends FileLoader
         $collection->addResource(new FileResource($path));
 
         // empty file
-        if (null === $config) {
+        if (null === $configParsed) {
             return $collection;
         }
 
         // not an array
-        if (!is_array($config)) {
+        if (!is_array($configParsed)) {
             throw new \InvalidArgumentException(sprintf('The file "%s" must contain a YAML array.', $path));
         }
 
-        foreach ($config as $name => $config) {
+        foreach ($configParsed as $name => $config) {
             $this->validate($config, $name, $path);
 
             if (isset($config['resource'])) {


### PR DESCRIPTION
The 'config' variable is already used as an array expression less... 

Using a variable both as an 'array expression' and as a 'key' or 'value' most often is a typing error.