### PR TITLE
PhpMatcherTrait: Fix typo in list function

### DIFF
--- a/Matcher/Dumper/PhpMatcherTrait.php
+++ b/Matcher/Dumper/PhpMatcherTrait.php
@@ -84,7 +84,7 @@ trait PhpMatcherTrait
         }
         $supportsRedirections = 'GET' === $canonicalMethod && $this instanceof RedirectableUrlMatcherInterface;
 
-        foreach ($this->staticRoutes[$trimmedPathinfo] ?? [] as list($ret, $requiredHost, $requiredMethods, $requiredSchemes, $hasTrailingSlash, , $condition)) {
+        foreach ($this->staticRoutes[$trimmedPathinfo] ?? [] as list($ret, $requiredHost, $requiredMethods, $requiredSchemes, $hasTrailingSlash, $condition)) {
             if ($condition && !($this->checkCondition)($condition, $context, 0 < $condition ? $request ?? $request = $this->request ?: $this->createRequest($pathinfo) : null)) {
                 continue;
             }


### PR DESCRIPTION
Uncaught PHP Exception ErrorException: "Notice: Undefined offset: 6" at vendor/symfony/routing/Matcher/Dumper/PhpMatcherTrait.php line 87